### PR TITLE
Remove Etsy.access_mode

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -45,7 +45,6 @@ For simple authentication from the console, configure the necessary parameters:
 
   Etsy.api_key = 'key'
   Etsy.api_secret = 'secret'
-  Etsy.access_mode = :authenticated
 
 From there, you will need to paste the verification URL into a browser:
 
@@ -71,7 +70,6 @@ configuration of a callback URL:
 
   Etsy.api_key = 'key'
   Etsy.api_secret = 'secret'
-  Etsy.access_mode = :authenticated
   Etsy.callback_url = 'http://localhost:4567/authorize'
 
 In this mode, you'll need to store the request token and secret before redirecting

--- a/lib/etsy.rb
+++ b/lib/etsy.rb
@@ -86,30 +86,6 @@ module Etsy
     @host || SANDBOX_HOST
   end
 
-  # Set the access mode, can either be :public or :authenticated.  Defaults to :public.
-  # and will raise an exception when set to an invalid value.
-  #
-  def self.access_mode=(mode)
-    unless [:authenticated, :public, :read_only, :read_write].include?(mode)
-      raise(ArgumentError, "access mode must be set to either :authenticated or :public")
-    end
-    if mode == :read_only
-      deprecate "Please set Etsy.access_mode to :public. Mode :read_only is no longer in use."
-      mode = :public
-    end
-    if mode == :read_write
-      deprecate "Please set Etsy.access_mode to :authenticated. Mode :read_write is no longer in use."
-      mode = :authenticated
-    end
-    @access_mode = mode
-  end
-
-  # The currently configured access mode
-  #
-  def self.access_mode
-    @access_mode || :public
-  end
-
   # The configured callback URL or 'oob' if no callback URL is configured. This controls
   # whether or not we need to pass the OAuth verifier by hand.
   #

--- a/lib/etsy/request.rb
+++ b/lib/etsy/request.rb
@@ -93,7 +93,7 @@ module Etsy
     end
 
     def secure?
-      Etsy.access_mode == :authenticated && !@token.nil? && !@secret.nil?
+      !@token.nil? && !@secret.nil?
     end
 
   end

--- a/test/unit/etsy_test.rb
+++ b/test/unit/etsy_test.rb
@@ -43,36 +43,6 @@ class EtsyTest < Test::Unit::TestCase
       Etsy.api_secret.should == 'secret'
     end
 
-    should "be in public mode by default" do
-      Etsy.access_mode.should == :public
-    end
-
-    should "be able to set the access mode to authenticated" do
-      Etsy.access_mode = :authenticated
-      Etsy.access_mode.should == :authenticated
-    end
-
-    should "be able to set the access mode to public" do
-      Etsy.access_mode = :public
-      Etsy.access_mode.should == :public
-    end
-
-    should "be backwards compatible with :read_only mode" do
-      Etsy.stubs(:deprecate)
-      Etsy.access_mode = :read_only
-      Etsy.access_mode.should == :public
-    end
-
-    should "be backwards compatible with :read_write mode" do
-      Etsy.stubs(:deprecate)
-      Etsy.access_mode = :read_write
-      Etsy.access_mode.should == :authenticated
-    end
-
-    should "raise an exception when attempting to set an invalid access mode" do
-      lambda { Etsy.access_mode = :invalid }.should raise_error(ArgumentError)
-    end
-
     should "know the host for the sandbox environment" do
       Etsy.environment = :sandbox
       Etsy.host.should == 'sandbox.openapi.etsy.com'


### PR DESCRIPTION
It's unnecessary - the presence of the OAuth info should be enough to infer authentication. You even explicitly have to add it to the options of each request!
