### PR TITLE
Model.get_all returns nil-initialized models if results is null

### DIFF
--- a/lib/etsy/model.rb
+++ b/lib/etsy/model.rb
@@ -22,12 +22,19 @@ module Etsy
 
       def get(endpoint, options = {})
         objects = get_all(endpoint, options)
-        (objects.length == 1) ? objects[0] : objects
+        if objects.length == 0
+          nil
+        elsif objects.length == 1
+          objects[0]
+        else
+          objects
+        end
       end
 
       def get_all(endpoint, options={})
         response = Request.get(endpoint, options)
-        [response.result].flatten.map do |data|
+        result = response.result || [] # result may be null
+        [result].flatten.map do |data|
           if options[:access_token] && options[:access_secret]
             new(data, options[:access_token], options[:access_secret])
           else


### PR DESCRIPTION
If `results` in the returned JSON is null, then get_all extracts a `[nil]` and initializes the model with it. This in turn also breaks Model.get.
