### PR TITLE
Send HTTP error code with error message, when JSON is invalid

### DIFF
--- a/lib/etsy/response.rb
+++ b/lib/etsy/response.rb
@@ -73,7 +73,7 @@ module Etsy
       raise MissingShopID             if missing_shop_id?
       raise InvalidUserID             if invalid_user_id?
       raise TemporaryIssue            if temporary_etsy_issue? || resource_unavailable? || exceeded_rate_limit?
-      raise EtsyJSONInvalid.new(data) unless valid_json?
+      raise EtsyJSONInvalid.new("CODE: #{code}, BODY: #{data}") unless valid_json?
       true
     end
 

--- a/test/unit/etsy/response_test.rb
+++ b/test/unit/etsy/response_test.rb
@@ -71,10 +71,11 @@ module Etsy
 
       should "raise an invalid JSON exception if the response is not json" do
         raw_response = mock
-        raw_response.stubs(:body => "I am not JSON")
+        raw_response.stubs(:body => "I am not JSON", :code => 500)
         r = Response.new(raw_response)
 
         lambda { r.to_hash }.should raise_error(Etsy::EtsyJSONInvalid)
+        lambda { r.to_hash }.should raise_error("CODE: 500, BODY: I am not JSON")
       end
 
       should "raise OAuthTokenRevoked" do


### PR DESCRIPTION
Some messages are blank and makes the errors hard to track down
