### PR TITLE
Inline the Etsy.host parameter in BasicClient

### DIFF
--- a/lib/etsy/basic_client.rb
+++ b/lib/etsy/basic_client.rb
@@ -8,8 +8,8 @@ module Etsy
 
     # Create a new client that will connect to the specified host
     #
-    def initialize(host)
-      @host = host
+    def initialize
+      @host = Etsy.host
     end
 
     def client # :nodoc:

--- a/lib/etsy/request.rb
+++ b/lib/etsy/request.rb
@@ -128,7 +128,7 @@ module Etsy
     end
 
     def basic_client
-      BasicClient.new(Etsy.host)
+      BasicClient.new
     end
 
     def secure?

--- a/test/unit/etsy/basic_client_test.rb
+++ b/test/unit/etsy/basic_client_test.rb
@@ -6,7 +6,8 @@ module Etsy
     context "An instance of the BasicClient class" do
 
       should "be able to construct a client" do
-        client = BasicClient.new('example.com')
+        Etsy.stubs(:host).returns 'example.com'
+        client = BasicClient.new
         Net::HTTP.stubs(:new).with('example.com').returns('client')
 
         client.client.should == 'client'
@@ -16,7 +17,7 @@ module Etsy
         http_client = stub()
         http_client.stubs(:get).with('endpoint').returns('response')
 
-        client = BasicClient.new('')
+        client = BasicClient.new
         client.stubs(:client).returns(http_client)
 
         client.get('endpoint').should == 'response'

--- a/test/unit/etsy/request_test.rb
+++ b/test/unit/etsy/request_test.rb
@@ -132,9 +132,8 @@ module Etsy
 
       should "know the client for read-only mode" do
         Etsy.stubs(:access_mode).returns(:read_only)
-        Etsy.stubs(:host).returns('example.com')
 
-        BasicClient.stubs(:new).with('example.com').returns('client')
+        BasicClient.stubs(:new).returns 'client'
 
         r = Request.new('')
 
@@ -143,9 +142,8 @@ module Etsy
 
       should "know the client for authenticated mode when there is no access token information" do
         Etsy.stubs(:access_mode).returns(:authenticated)
-        Etsy.stubs(:host).returns('example.com')
 
-        BasicClient.stubs(:new).with('example.com').returns('client')
+        BasicClient.stubs(:new).returns 'client'
 
         r = Request.new('')
 


### PR DESCRIPTION
We call Etsy.host directly in the SecureClient, and we
don't really gain anything in the BasicClient by injecting it.

@rogsmith Want to sanity check this and merge it in if you like it?
