### PR TITLE
Make api_key and api_secret thread safe

### DIFF
--- a/lib/etsy.rb
+++ b/lib/etsy.rb
@@ -63,9 +63,24 @@ module Etsy
   class Error < RuntimeError; end
 
   class << self
-    attr_accessor :api_key, :api_secret
     attr_writer :callback_url
     attr_writer :permission_scopes
+  end
+
+  # Make Etsy.api_key and Etsy.api_secret thread safe
+  #
+  def self.api_key
+    Thread.current[:etsy_api_key]
+  end
+
+  def self.api_key=(val)
+    Thread.current[:etsy_api_key] = val
+  end
+  def self.api_secret
+    Thread.current[:etsy_api_secret]
+  end
+  def self.api_secret=(val)
+    Thread.current[:etsy_api_secret] = val
   end
 
   SANDBOX_HOST = 'sandbox.openapi.etsy.com'


### PR DESCRIPTION
This is a hackety hack, but it makes Etsy.api_key and Etsy.api_secret thread safe.  I need it so I can use the client in a Sidekiq job.

The right thing is probably an API break, where these fields get moved onto Etsy as instance variables, but that seemed a bit presumptuous.  
