### PR TITLE
Rake is now not verbose, tests don't put out file names

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,5 +8,5 @@ task :default => :test
 Rake::TestTask.new do |t|
   t.libs << 'test'
   t.test_files = FileList["test/**/*_test.rb"]
-  t.verbose = true
+  t.verbose = false
 end


### PR DESCRIPTION
Running `rake test` used to put out all the file names to the terminal. Now that doesn't happen anymore. 
