### PR TITLE
Make HTTPS the default protocol

### DIFF
--- a/lib/etsy.rb
+++ b/lib/etsy.rb
@@ -105,7 +105,7 @@ module Etsy
   end
   
   def self.protocol
-    @protocol || "http"
+    @protocol || "https"
   end
 
   # The currently configured environment.

--- a/test/unit/etsy/basic_client_test.rb
+++ b/test/unit/etsy/basic_client_test.rb
@@ -7,6 +7,7 @@ module Etsy
 
       should "be able to construct a client" do
         Etsy.stubs(:host).returns 'example.com'
+        Etsy.stubs(:protocol).returns 'http'
         client = BasicClient.new
         Net::HTTP.stubs(:new).with('example.com', 80).returns('client')
 

--- a/test/unit/etsy/secure_client_test.rb
+++ b/test/unit/etsy/secure_client_test.rb
@@ -13,7 +13,7 @@ module Etsy
         Etsy.stubs(:permission_scopes).returns(['scope_one', 'scope_two'])
 
         OAuth::Consumer.stubs(:new).with('key', 'secret', {
-          :site               => 'http://sandbox',
+          :site               => 'https://sandbox',
           :request_token_path => '/v2/oauth/request_token?scope=scope_one+scope_two',
           :access_token_path  => '/v2/oauth/access_token',
         }).returns('consumer')
@@ -31,7 +31,7 @@ module Etsy
         Etsy.stubs(:permission_scopes).returns(['scope_one', 'scope_two'])
 
         OAuth::Consumer.stubs(:new).with('key', 'secret', {
-          :site               => 'http://production',
+          :site               => 'https://production',
           :request_token_path => '/v2/oauth/request_token?scope=scope_one+scope_two',
           :access_token_path  => '/v2/oauth/access_token',
         }).returns('consumer')

--- a/test/unit/etsy_test.rb
+++ b/test/unit/etsy_test.rb
@@ -26,6 +26,10 @@ class EtsyTest < Test::Unit::TestCase
       Etsy.user('littletjane').should == user
     end
 
+    should "use the https protocol by default" do
+      Etsy.protocol.should == "https"
+    end
+
     should "be able to set the protocol to a valid value" do
       Etsy.protocol = 'http'
       Etsy.protocol.should == 'http'


### PR DESCRIPTION
Hey there! Thanks for the great work on this gem. I've been using it for well over a year on [The Haberdash Fox](http://www.thehaberdashfox.com/) and have really enjoyed it!

This PR make HTTPS the default protocol. It appears that all new API keys that Etsy is giving out these days (as of late 2013ish) no longer allow plain HTTP. I have a set of older keys for which HTTP is still seemingly valid, but when I create a new app in my Etsy developer page, and plug the same keys into the old app, the app fails.

I monkey patched the request (per your [README](https://github.com/kytrinyx/etsy#monkey-patch)) and realized that `Etsy::EtsyJSONInvalid: API requests must be made over HTTPS`. See this tinnnnnny section of the [Etsy docs](https://www.etsy.com/developers/documentation/getting_started/api_basics#section_accessing_the_api) for more info ;P

@pupca had already done all of the hard work in #64, so my fix was just a single letter. I did take the opportunity to update the getter/setter specs in 0963c63, which passed instantly, and added a spec to verify the default protocol was HTTPS in 47cacea, which failed. I changed the default in the next commit (96982ab), which made the previous spec pass, but broke one test for Basic Client and two for Secure Client. The final commit e8267ae resolves the issue and all specs are passing.

Let me know if this PR is weird or needs adjusting. Super happy to help out. Thanks again for the hard work! :sparkles: 
