### PR TITLE
Fix Listing#is_supply method

### DIFF
--- a/lib/etsy/listing.rb
+++ b/lib/etsy/listing.rb
@@ -248,6 +248,10 @@ module Etsy
       (user_ids.size > 0) ? Array(Etsy::User.find(user_ids, options)) : []
     end
 
+    def is_supply
+      @result.fetch('is_supply') == 'true'
+    end
+
     private
 
     def self.valid?(state)

--- a/lib/etsy/listing.rb
+++ b/lib/etsy/listing.rb
@@ -248,10 +248,6 @@ module Etsy
       (user_ids.size > 0) ? Array(Etsy::User.find(user_ids, options)) : []
     end
 
-    def is_supply
-      !!@result.fetch("is_supply")
-    end
-
     private
 
     def self.valid?(state)

--- a/test/fixtures/listing/findAllShopListings.json
+++ b/test/fixtures/listing/findAllShopListings.json
@@ -23,7 +23,8 @@
         "brightness": 100,
         "is_black_and_white": false,
         "url": "http://www.etsy.com/listing/59495892/initials-carved-into-tree-love-stamp",
-        "views": 37
+        "views": 37,
+        "is_supply": "false"
     },
     {
         "listing_id": 59495804,
@@ -48,7 +49,8 @@
         "brightness": 100,
         "is_black_and_white": false,
         "url": "http://www.etsy.com/listing/59495804/faux-bois-heart-hand-carved-stamp",
-        "views": 78
+        "views": 78,
+        "is_supply": "true"
     }],
     "params": {
         "limit": "2",

--- a/test/unit/etsy/listing_test.rb
+++ b/test/unit/etsy/listing_test.rb
@@ -188,6 +188,10 @@ module Etsy
         should "have a value for :black_and_white?" do
           @listing.black_and_white?.should == false
         end
+
+        should "have a value for :is_supply?" do
+          @listing.is_supply.should == false
+        end
       end
 
       %w(active removed sold_out expired alchemy).each do |state|

--- a/test/unit/etsy/listing_test.rb
+++ b/test/unit/etsy/listing_test.rb
@@ -78,7 +78,6 @@ module Etsy
           Listing.stubs(:find).with([1, 2], {:other => :params}).returns(['listings'])
 
           Listing.find_all_by_shop_id(1, :state => :sold, :other => :params).should == ['listings']
-
         end
 
         should "not ask the API for listings if there are no transactions" do


### PR DESCRIPTION
This method is always return `true`

```
# [1] pry(main)> !!{"is_supply" => "true"}.fetch("is_supply")
# => true
# [2] pry(main)> !!{"is_supply" => "false"}.fetch("is_supply")
# => true
```
